### PR TITLE
Fix lost http server startup errors

### DIFF
--- a/httpserver/server.go
+++ b/httpserver/server.go
@@ -40,10 +40,11 @@ func (srv *HTTPServer) Run(ctx context.Context, address string, shutdownWaitTime
 		}()
 		err = httpServer.ListenAndServe()
 		if err != nil {
-			if err != http.ErrServerClosed {
+			if err == http.ErrServerClosed {
+				err = nil
+			} else {
 				err = fmt.Errorf("Failed to listen and start http server: %w", err)
 			}
-			err = nil
 		}
 	}()
 


### PR DESCRIPTION
It helps to preserve err if you don't set it to nil.

Fixes #7