### PR TITLE
Add pprof routes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ WORKDIR /go/src/app
 
 COPY . .
 RUN if [ ! -f vendor/modules.txt ]; then go mod download; fi
-RUN CGO_ENABLED=0 go build -o /go/bin/fletchling ./bin/fletchling
+RUN CGO_ENABLED=0 go build -tags go_json -o /go/bin/fletchling ./bin/fletchling
 RUN CGO_ENABLED=0 go build -o /go/bin/fletchling-osm-importer ./bin/fletchling-osm-importer
 RUN mkdir /empty-dir
 

--- a/httpserver/routes.go
+++ b/httpserver/routes.go
@@ -1,6 +1,8 @@
 package httpserver
 
 import (
+	"net/http/pprof"
+
 	"github.com/gin-gonic/gin"
 )
 
@@ -34,4 +36,27 @@ func (srv *HTTPServer) setupRoutes() {
 	statsGroup.PUT("/purge/keep", srv.handlePurgeKeepStats)
 	statsGroup.PUT("/purge/oldest", srv.handlePurgeOldestStats)
 	statsGroup.PUT("/purge/newest", srv.handlePurgeNewestStats)
+
+	debugGroup := r.Group("/debug/pprof")
+	debugGroup.GET("/cmdline", func(c *gin.Context) {
+		pprof.Cmdline(c.Writer, c.Request)
+	})
+	debugGroup.GET("/heap", func(c *gin.Context) {
+		pprof.Index(c.Writer, c.Request)
+	})
+	debugGroup.GET("/block", func(c *gin.Context) {
+		pprof.Index(c.Writer, c.Request)
+	})
+	debugGroup.GET("/mutex", func(c *gin.Context) {
+		pprof.Index(c.Writer, c.Request)
+	})
+	debugGroup.GET("/trace", func(c *gin.Context) {
+		pprof.Trace(c.Writer, c.Request)
+	})
+	debugGroup.GET("/profile", func(c *gin.Context) {
+		pprof.Profile(c.Writer, c.Request)
+	})
+	debugGroup.GET("/symbol", func(c *gin.Context) {
+		pprof.Symbol(c.Writer, c.Request)
+	})
 }

--- a/httpserver/webhooks.go
+++ b/httpserver/webhooks.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"gopkg.in/guregu/null.v4"
@@ -92,6 +93,8 @@ func (wh *PokemonWebhook) EncounterIdAsInt() (uint64, error) {
 func (srv *HTTPServer) processMessages(msgs []WebhookMessage) {
 	var numProcessed int
 
+	now := time.Now()
+
 	for _, msg := range msgs {
 		pokemon := msg.Pokemon
 		if pokemon == nil {
@@ -131,7 +134,7 @@ func (srv *HTTPServer) processMessages(msgs []WebhookMessage) {
 		numProcessed++
 	}
 
-	srv.logger.Debugf("processed %d pokemon from single webhook", numProcessed)
+	srv.logger.Debugf("processed %d pokemon from single webhook in %s", numProcessed, time.Now().Sub(now).Truncate(time.Millisecond))
 }
 
 func (srv *HTTPServer) handleWebhook(c *gin.Context) {


### PR DESCRIPTION
Adds pprof routes under /debug/pprof to use with 'go tool pprof'.

Adjusts some logging and use go_json build tag in Dockerfile to match the Makefile.