### PR TITLE
GC debug route fiddling

### DIFF
--- a/httpserver/routes.go
+++ b/httpserver/routes.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"net/http/pprof"
 	"runtime"
+	"runtime/debug"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -41,13 +42,32 @@ func (srv *HTTPServer) setupRoutes() {
 	statsGroup.PUT("/purge/newest", srv.handlePurgeNewestStats)
 
 	debugGroup := r.Group("/debug")
-	debugGroup.PUT("/gc-flush", func(c *gin.Context) {
+
+	// run the GC. I guess this is also available via '/debug/pprof/heap?gc=1"
+	debugGroup.PUT("/gc/flush", func(c *gin.Context) {
 		now := time.Now()
+		srv.logger.Info("/gc/flush: starting garbage collector")
 		runtime.GC()
+		duration := time.Now().Sub(now).Truncate(time.Millisecond)
+		srv.logger.Infof("/gc/flush: garbage collector ran in %s", duration)
 		resp := struct {
 			Message    string `json:"message"`
 			DurationMs int64  `json:"duration_ms"`
-		}{"garbage collector has been run", time.Now().Sub(now).Milliseconds()}
+		}{"garbage collector has been run.", duration.Milliseconds()}
+		c.JSON(http.StatusOK, &resp)
+	})
+
+	// run the GC and return as much memory to OS as possible.
+	debugGroup.PUT("/gc/free", func(c *gin.Context) {
+		now := time.Now()
+		srv.logger.Info("/gc/free: starting garbage collector and memory freeing")
+		debug.FreeOSMemory()
+		duration := time.Now().Sub(now).Truncate(time.Millisecond)
+		srv.logger.Infof("/gc/free: garbage collector and memory freeing ran in %s", duration)
+		resp := struct {
+			Message    string `json:"message"`
+			DurationMs int64  `json:"duration_ms"`
+		}{"garbage collector has been run and memory freed.", duration.Milliseconds()}
 		c.JSON(http.StatusOK, &resp)
 	})
 


### PR DESCRIPTION
Rename /debug/gc-flush to /debug/gc/flush. Turns out pprof has this available, also, via /debug/pprof/heap?gc=1. Oh well.

Add 'PUT /debug/gc/free'. This route calls (runtime/)debug.FreeOSMemory(), which runs the GC and then tries to return as much memory to the OS as possible.