### PR TITLE
feat: add status endpoint and check in docker-compose example

### DIFF
--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -11,6 +11,12 @@ services:
       - /etc/localtime:/etc/localtime:ro
     ports:
       - "9042:9042"
+    healthcheck:
+      test: curl --fail http://localhost:9042/status || exit 1
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
 
   # a container that starts and sleeps. this can be used
   # to exec into for the importer. See the 'docker-osm-importer.sh'

--- a/docs/API.md
+++ b/docs/API.md
@@ -46,3 +46,8 @@ Purges the specified amount of minutes of stats starting from the newest. 'inclu
 `curl -X PUT http://localhost:9042/api/stats/purge/keep -d '{ "duration_minutes": xx }'`
 
 This is another way to purge oldest stats. But with this one, you specify the duration to keep, not the duration to purge.
+
+# Healthcheck status endpoint
+
+## Get status
+`curl http://localhost:9042/status`

--- a/httpserver/routes.go
+++ b/httpserver/routes.go
@@ -20,6 +20,11 @@ func (srv *HTTPServer) setupRoutes() {
 
 	r.Use(gin.RecoveryWithWriter(srv.logger.Writer()))
 
+	// unrestricted /status endpoint
+	r.GET("/status", func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"status": "ok"})
+	})
+
 	r.POST("/webhook", srv.handleWebhook)
 
 	apiGroup := r.Group("/api", srv.authorizeAPI)


### PR DESCRIPTION
- Add `/status` endpoint (for monitoring tools needs.)
- Add docker-compose health check

Untested but should work.
