### PR TITLE
fix old docker compose CLI used in script

### DIFF
--- a/docker-osm-importer.sh
+++ b/docker-osm-importer.sh
@@ -4,4 +4,11 @@
 
 cd `dirname $0`
 
-docker compose exec fletchling-tools ./fletchling-osm-importer "$@"
+which docker-compose > /dev/null
+if [ $? -eq 0 ]; then
+  command='docker-compose'
+else
+  command='docker compose'
+fi
+
+$command exec fletchling-tools ./fletchling-osm-importer "$@"

--- a/docker-osm-importer.sh
+++ b/docker-osm-importer.sh
@@ -4,4 +4,4 @@
 
 cd `dirname $0`
 
-docker-compose exec fletchling-tools ./fletchling-osm-importer "$@"
+docker compose exec fletchling-tools ./fletchling-osm-importer "$@"


### PR DESCRIPTION
Since three years ago, compose is included in docker CLI. You don't need to install any compose plugin on top of docker. Because of that, the command to use it is now `docker compose` and not `docker-compose`.