### PR TITLE
Skip unsupported shapes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ FROM golang:1.22-alpine as build
 WORKDIR /go/src/app
 
 COPY . .
+RUN find db_store/sql -name '*~' -delete
 RUN if [ ! -f vendor/modules.txt ]; then go mod download; fi
 RUN CGO_ENABLED=0 go build -tags go_json -o /go/bin/fletchling ./bin/fletchling
 RUN CGO_ENABLED=0 go build -o /go/bin/fletchling-osm-importer ./bin/fletchling-osm-importer

--- a/db_store/nests.go
+++ b/db_store/nests.go
@@ -128,6 +128,10 @@ func (st *NestsDBStore) updateNestPartial(ctx context.Context, queryer dbQueryer
 	args[n] = nestId
 	n++
 
+	if st.logger.Level >= logrus.DebugLevel {
+		st.logger.Debugf("Running partial nest DB update: %s, %#v", query.String(), args[:n])
+	}
+
 	_, err := queryer.ExecContext(ctx, query.String(), args[:n]...)
 	return err
 }

--- a/db_store/sql/2_nests.up.sql
+++ b/db_store/sql/2_nests.up.sql
@@ -6,6 +6,7 @@ ALTER TABLE nests
     MODIFY `lon` double NOT NULL;
 
 -- Add procedure for overlap disablement
+-- Stolen graciously from nestcollector (thank you).
 CREATE PROCEDURE fl_nest_filter_overlap (IN maximum_overlap double)
 BEGIN
   DROP TEMPORARY TABLE IF EXISTS overlapNest;

--- a/filters/db_refresher.go
+++ b/filters/db_refresher.go
@@ -2,7 +2,6 @@ package filters
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"time"
 
@@ -31,7 +30,7 @@ type DBRefresher struct {
 }
 
 func (refresher *DBRefresher) refreshNest(ctx context.Context, config RefreshNestConfig, nest db_store.Nest) (db_store.Nest, error) {
-	fullName := fmt.Sprintf("%s(%d)", nest.FullName(), nest.NestId)
+	fullName := nest.FullName()
 
 	var partialUpdate *db_store.NestPartialUpdate
 
@@ -175,6 +174,12 @@ func (refresher *DBRefresher) refreshNest(ctx context.Context, config RefreshNes
 		makePartialUpdate()
 		nest.PokemonId.Valid = false
 		partialUpdate.PokemonId = &nest.PokemonId
+		nest.PokemonForm.Valid = false
+		partialUpdate.PokemonForm = &nest.PokemonForm
+		nest.PokemonAvg.Valid = false
+		partialUpdate.PokemonAvg = &nest.PokemonAvg
+		nest.PokemonCount.Valid = false
+		partialUpdate.PokemonCount = &nest.PokemonCount
 	}
 
 	if partialUpdate == nil {
@@ -228,7 +233,7 @@ func (refresher *DBRefresher) RefreshAllNests(ctx context.Context, config Refres
 	if config.MaxOverlapPercent < 0 || config.MaxOverlapPercent >= 100 {
 		refresher.logger.Infof("DB-REFRESHER: Skipping overlap disablement due to overlap_max_percent=%0.3f", config.MaxOverlapPercent)
 	} else {
-		refresher.logger.Infof("Starting overlap disabling... this may take a while...")
+		refresher.logger.Infof("DB-REFRESHER: Starting overlap disabling... this may take a while...")
 		numDisabled, err := refresher.nestsDBStore.DisableOverlappingNests(ctx, config.MaxOverlapPercent)
 		if err != nil {
 			refresher.logger.Errorf("DB-REFRESHER: Overlap disablement errored: %v", err)

--- a/geo/util.go
+++ b/geo/util.go
@@ -37,6 +37,16 @@ func idIsValid(id any) (int64, error) {
 	return nestId, nil
 }
 
+func GeometrySupported(geometry orb.Geometry) bool {
+	switch geometry.GeoJSONType() {
+	case "Polygon":
+	case "MultiPolygon":
+	default:
+		return false
+	}
+	return true
+}
+
 func NameAndIntIdFromFeature(feature *geojson.Feature) (string, null.String, int64, error) {
 	var areaName null.String
 


### PR DESCRIPTION
* importer: osm data can return LineStrings for routes, so skip those.
* refresher: ensure nests already in DB with bad shapes are disabled and never enabled. This should prevent overlap query from seeing the bad shapes.
* refresher: always compute nest area and update DB if it changes.

Fixes #35