### PR TITLE
Fix Docker compose healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN CGO_ENABLED=0 go build -o /go/bin/sleep ./bin/sleep
 RUN mkdir /empty-dir
 
 # Now copy it into our base image.
-FROM gcr.io/distroless/static-debian11 as runner
+FROM debian:stable-slim as runner
+RUN apt update && apt-get install -y curl
 COPY --from=build /empty-dir /fletchling/logs
 COPY --from=build /go/src/app/db_store/sql /fletchling/db_store/sql
 COPY --from=build /go/bin/fletchling /go/bin/fletchling-osm-importer /go/bin/sleep /fletchling/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM busybox:uclibc AS busybox
+
 # Build image
 FROM golang:1.22-alpine as build
 
@@ -12,8 +14,8 @@ RUN CGO_ENABLED=0 go build -o /go/bin/sleep ./bin/sleep
 RUN mkdir /empty-dir
 
 # Now copy it into our base image.
-FROM debian:stable-slim as runner
-RUN apt update && apt-get install -y curl
+FROM gcr.io/distroless/static-debian11 as runner
+COPY --from=busybox /bin/wget /usr/bin/wget
 COPY --from=build /empty-dir /fletchling/logs
 COPY --from=build /go/src/app/db_store/sql /fletchling/db_store/sql
 COPY --from=build /go/bin/fletchling /go/bin/fletchling-osm-importer /go/bin/sleep /fletchling/

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -12,7 +12,7 @@ services:
     ports:
       - "9042:9042"
     healthcheck:
-      test: curl --fail http://localhost:9042/status || exit 1
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:9042/status"]
       interval: 60s
       timeout: 30s
       retries: 3


### PR DESCRIPTION
gcr.io/distroless/static-debian11 doesn't include curl by default, and because it's distroless. There is not really an obvious way (from what I can see) to get it installed.

Proposal is to change base image to debian:stable-slim and install curl into the container.
This will increase the image size by 4x, from what I could test on my own machine, and not as "secure" as a distroless.

So just opening the discussion now, if we should have a working healthcheck or not 😄 