### PR TITLE
Add 2 new tools

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,8 @@
 /.git
 /docker-compose.yml*
 /fletchling
+/fletchling-db-exporter
+/fletchling-db-refresher
 /fletchling-osm-importer
 /Makefile
 /configs

--- a/.gitignore
+++ b/.gitignore
@@ -25,8 +25,9 @@ go.work
 /configs/fletchling-osm-importer.toml
 /fletchling
 /fletchling-osm-importer
+/fletchling-db-exporter
+/fletchling-db-refresher
 /docker-compose.yml
 /vendor
 /logs
 .idea/
-

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ RUN find db_store/sql -name '*~' -delete
 RUN if [ ! -f vendor/modules.txt ]; then go mod download; fi
 RUN CGO_ENABLED=0 go build -tags go_json -o /go/bin/fletchling ./bin/fletchling
 RUN CGO_ENABLED=0 go build -o /go/bin/fletchling-osm-importer ./bin/fletchling-osm-importer
+RUN CGO_ENABLED=0 go build -o /go/bin/fletchling-db-refresher ./bin/fletchling-db-refresher
+RUN CGO_ENABLED=0 go build -o /go/bin/fletchling-db-exporter ./bin/fletchling-db-exporter
 RUN CGO_ENABLED=0 go build -o /go/bin/sleep ./bin/sleep
 RUN mkdir /empty-dir
 
@@ -15,7 +17,7 @@ RUN mkdir /empty-dir
 FROM gcr.io/distroless/static-debian11 as runner
 COPY --from=build /empty-dir /fletchling/logs
 COPY --from=build /go/src/app/db_store/sql /fletchling/db_store/sql
-COPY --from=build /go/bin/fletchling /go/bin/fletchling-osm-importer /go/bin/sleep /fletchling/
+COPY --from=build /go/bin/fletchling /go/bin/fletchling-osm-importer /go/bin/fletchling-db-refresher /go/bin/fletchling-db-exporter /go/bin/sleep /fletchling/
 
 WORKDIR /fletchling
 CMD ["./fletchling"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-all: fletchling fletchling-osm-importer
+ALL=fletchling fletchling-db-refresher fletchling-db-exporter fletchling-osm-importer
+
+all: $(ALL)
 
 deps:
 	if [ ! -f vendor/modules.txt ]; then go mod download; fi
@@ -6,8 +8,14 @@ deps:
 fletchling: deps
 	CGO_ENABLED=0 go build -tags go_json ./bin/fletchling/...
 
+fletchling-db-refresher: deps
+	CGO_ENABLED=0 go build ./bin/fletchling-db-refresher/...
+
+fletchling-db-exporter: deps
+	CGO_ENABLED=0 go build ./bin/fletchling-db-exporter/...
+
 fletchling-osm-importer: deps
 	CGO_ENABLED=0 go build ./bin/fletchling-osm-importer/...
 
 clean:
-	rm -f fletchling fletchling-osm-importer
+	rm -f $(ALL)

--- a/app_config/config.go
+++ b/app_config/config.go
@@ -3,6 +3,7 @@ package app_config
 import (
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -87,8 +88,8 @@ func (cfg *Config) GetPrometheusConfig() stats_collector.PrometheusConfig {
 	return cfg.Prometheus
 }
 
-func (cfg *Config) CreateLogger(rotate bool) *logrus.Logger {
-	return cfg.Logging.CreateLogger(rotate, true)
+func (cfg *Config) CreateLogger(rotate bool, teeWriter io.Writer) (*logrus.Logger, error) {
+	return cfg.Logging.CreateLogger(rotate, true, teeWriter)
 }
 
 func (cfg *Config) Validate() error {

--- a/bin/fletchling-db-exporter/fletchling-db-exporter.go
+++ b/bin/fletchling-db-exporter/fletchling-db-exporter.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+
+	"github.com/UnownHash/Fletchling/app_config"
+	"github.com/UnownHash/Fletchling/db_store"
+	"github.com/UnownHash/Fletchling/version"
+	"github.com/paulmach/orb/geojson"
+)
+
+const (
+	LOGFILE_NAME                  = "fletchling-db-exporter.log"
+	DEFAULT_CONFIG_FILENAME       = "./configs/fletchling.toml"
+	DEFAULT_NESTS_MIGRATIONS_PATH = "./db_store/sql"
+)
+
+func usage(flagSet *flag.FlagSet, output io.Writer) {
+	fmt.Fprintf(output, `** A wild Fletchling has appeared. Version %s **
+Usage: %s [-help] [-debug] [-f configfile] [-include-inactive] [-all-areas] [-area <area-name>]
+
+%s is used to export multiple nests from the DB as a geojson FeatureCollection
+or a single nest as a geojson Feature.
+
+Output will go to stdout, so just redirect output to a file. Logging
+will go to stderr and to a logfile.
+`,
+		version.APP_VERSION, os.Args[0], os.Args[0])
+
+	fmt.Fprint(output, "Options:\n")
+	flagSet.SetOutput(output)
+	flagSet.PrintDefaults()
+
+	fmt.Fprintf(output, `
+Examples (follow unix shell escaping rules!):
+%s -all-areas > all-areas.geojson
+%s -area 'My Area Name' > myarea.geojson
+%s -area "My Area's Name" > myarea.geojson
+%s -nest-id 12345 > mynest.geojson
+`,
+		os.Args[0], os.Args[0], os.Args[0], os.Args[0])
+}
+
+func main() {
+	flagSet := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	helpFlag := flagSet.Bool("help", false, "help!")
+	debugFlag := flagSet.Bool("debug", false, "override config and turn on debug logging")
+	flagSet.BoolVar(helpFlag, "h", false, "help!")
+	configFileFlag := flagSet.String("f", DEFAULT_CONFIG_FILENAME, "config file to use")
+	includeInactiveFlag := flagSet.Bool("include-inactive", false, "include inactive nests, also")
+	allAreasFlag := flagSet.Bool("all-areas", false, "import all areas found in your areas source")
+	onlyAreaFlag := flagSet.String("area", "", "export only 1 area")
+	nestIdFlag := flagSet.Int64("nest-id", 0, "export only 1 nest")
+	versionFlag := flagSet.Bool("version", false, "print the version of this tool and exit")
+
+	err := flagSet.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s", err)
+		usage(flagSet, os.Stderr)
+		os.Exit(2)
+	}
+
+	if *helpFlag {
+		usage(flagSet, os.Stdout)
+		os.Exit(0)
+	}
+
+	if *versionFlag {
+		fmt.Fprintf(os.Stdout, "%s\n", version.APP_VERSION)
+		os.Exit(0)
+	}
+
+	if len(flagSet.Args()) > 0 {
+		usage(flagSet, os.Stderr)
+		os.Exit(0)
+	}
+
+	if *allAreasFlag {
+		if *onlyAreaFlag != "" || *nestIdFlag != 0 {
+			fmt.Fprint(os.Stderr, "Error: do not specify an '-area' or '-nest-id' if '-all-areas' is given\n")
+			fmt.Fprintf(os.Stderr, "Try %s -help for help.\n", os.Args[0])
+			os.Exit(1)
+		}
+	} else if *onlyAreaFlag != "" && *nestIdFlag != 0 {
+		fmt.Fprint(os.Stderr, "Error: do not specify an '-area' if '-nest-id' is given\n")
+		fmt.Fprintf(os.Stderr, "Try %s -help for help.\n", os.Args[0])
+		os.Exit(1)
+	} else if *onlyAreaFlag == "" && *nestIdFlag == 0 {
+		fmt.Fprint(os.Stderr, "Error: one of '-all-areas', '-area', or '-nest-id' is required\n")
+		fmt.Fprintf(os.Stderr, "Try %s -help for help.\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	defaultConfig := app_config.GetDefaultConfig()
+	configFilename := *configFileFlag
+
+	cfg, err := app_config.LoadConfig(configFilename, defaultConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	cfg.Logging.Filename = LOGFILE_NAME
+
+	if *debugFlag {
+		cfg.Logging.Debug = true
+	}
+
+	logger, err := cfg.CreateLogger(true, os.Stderr)
+	if err != nil {
+		log.Fatal(err)
+	}
+	logger.Infof("STARTUP: Version %s. Config loaded.", version.APP_VERSION)
+
+	// check destination first before we attempt to load
+	// area fences.
+	nestsDBStore, err := db_store.NewNestsDBStore(cfg.NestsDb, logger)
+	if err != nil {
+		logger.Errorf("failed to init nests db for db importer: %v", err)
+		os.Exit(1)
+	}
+
+	if _, _, err := nestsDBStore.CheckMigrate(DEFAULT_NESTS_MIGRATIONS_PATH); err != nil {
+		logger.Errorf("error initing nests db: %v", err)
+		os.Exit(1)
+	}
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer cancelFn()
+
+		sig_ch := make(chan os.Signal, 1)
+		signal.Notify(sig_ch, syscall.SIGINT, syscall.SIGTERM)
+		select {
+		case <-ctx.Done():
+			// something else told us to exit
+		case sig := <-sig_ch:
+			logger.Infof("received signal '%s'", sig.String())
+		}
+	}()
+
+	encoder := json.NewEncoder(os.Stdout)
+
+	if *nestIdFlag != 0 {
+		nest, err := nestsDBStore.GetNestById(ctx, *nestIdFlag)
+
+		if err != nil {
+			logger.Fatalf("failed to get nest from DB: %v", err)
+		}
+
+		if nest == nil {
+			logger.Fatalf("nest %d not found", *nestIdFlag)
+		}
+
+		feature, err := nest.AsFeature()
+		if err != nil {
+			logger.Fatal(err)
+		}
+
+		err = encoder.Encode(feature)
+		if err != nil {
+			logger.Fatal(err)
+		}
+	}
+
+	areasProcessed := make(map[string]int)
+	featureCollection := geojson.NewFeatureCollection()
+
+	nestsCh := make(chan db_store.Nest, 64)
+
+	var streamWg sync.WaitGroup
+	defer streamWg.Wait()
+
+	streamWg.Add(1)
+	go func() {
+		defer streamWg.Done()
+
+		for {
+			var nest db_store.Nest
+			var ok bool
+
+			select {
+			case <-ctx.Done():
+				return
+			case nest, ok = <-nestsCh:
+				if !ok {
+					return
+				}
+			}
+
+			if !*includeInactiveFlag && !nest.Active.ValueOrZero() {
+				continue
+			}
+
+			areaName := nest.AreaName.ValueOrZero()
+			if splitted := strings.Split(areaName, "/"); len(splitted) == 2 {
+				areaName = splitted[1]
+			}
+
+			if *onlyAreaFlag != "" && *onlyAreaFlag != areaName {
+				continue
+			}
+
+			feature, err := nest.AsFeature()
+			if err != nil {
+				logger.Warn(err)
+				continue
+			}
+
+			areasProcessed[areaName]++
+
+			featureCollection.Append(feature)
+		}
+	}()
+
+	logger.Infof("Starting export...")
+
+	err = nestsDBStore.StreamNests(ctx, db_store.StreamNestsOpts{IncludePolygon: true}, nestsCh)
+	if err != nil {
+		logger.Fatal(err)
+	}
+
+	streamWg.Wait()
+
+	err = encoder.Encode(featureCollection)
+	if err != nil {
+		logger.Fatal(err)
+	}
+}

--- a/bin/fletchling-db-refresher/fletchling-db-refresher.go
+++ b/bin/fletchling-db-refresher/fletchling-db-refresher.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+
+	"github.com/UnownHash/Fletchling/app_config"
+	"github.com/UnownHash/Fletchling/db_store"
+	"github.com/UnownHash/Fletchling/filters"
+	"github.com/UnownHash/Fletchling/version"
+)
+
+const (
+	LOGFILE_NAME                  = "fletchling-db-refresher.log"
+	DEFAULT_CONFIG_FILENAME       = "./configs/fletchling.toml"
+	DEFAULT_NESTS_MIGRATIONS_PATH = "./db_store/sql"
+)
+
+func usage(flagSet *flag.FlagSet, output io.Writer) {
+	fmt.Fprintf(output, `** A wild Fletchling has appeared. Version %s **
+Usage: %s [-help] [-debug] [-f configfile] [-all-spawnpoints]
+
+%s is used to re-run the filtering of nests in the DB.
+This will activate and deactivate nests based on your current configuration
+under the 'filters' section.
+
+As a part of this, spawnpoints will be computed for a nest if they are not
+already known or if the -all-spawnpoints option was given. (This occurs only
+if the Golbat DB is configured.)
+
+This does not reload Fletchling afterwards. You will need to issue the API
+call.
+
+`,
+		version.APP_VERSION, os.Args[0], os.Args[0])
+
+	fmt.Fprint(output, "Options:\n")
+	flagSet.SetOutput(output)
+	flagSet.PrintDefaults()
+	fmt.Fprint(output, "\n")
+}
+
+func main() {
+	flagSet := flag.NewFlagSet(os.Args[0], flag.ExitOnError)
+
+	helpFlag := flagSet.Bool("help", false, "help!")
+	debugFlag := flagSet.Bool("debug", false, "override config and turn on debug logging")
+	flagSet.BoolVar(helpFlag, "h", false, "help!")
+	configFileFlag := flagSet.String("f", DEFAULT_CONFIG_FILENAME, "config file to use")
+	allSpawnpointsFlag := flagSet.Bool("all-spawnpoints", false, "re-compute spawnpoints for all nests, even if they are already known")
+	versionFlag := flagSet.Bool("version", false, "print the version of this tool and exit")
+
+	err := flagSet.Parse(os.Args[1:])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %s", err)
+		usage(flagSet, os.Stderr)
+		os.Exit(2)
+	}
+
+	if *helpFlag {
+		usage(flagSet, os.Stdout)
+		os.Exit(0)
+	}
+
+	if *versionFlag {
+		fmt.Fprintf(os.Stdout, "%s\n", version.APP_VERSION)
+		os.Exit(0)
+	}
+
+	if args := flagSet.Args(); len(args) != 0 {
+		usage(flagSet, os.Stdout)
+		os.Exit(1)
+	}
+
+	defaultConfig := app_config.GetDefaultConfig()
+	configFilename := *configFileFlag
+
+	cfg, err := app_config.LoadConfig(configFilename, defaultConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+	cfg.Logging.Filename = LOGFILE_NAME
+
+	if *debugFlag {
+		cfg.Logging.Debug = true
+	}
+
+	logger, err := cfg.CreateLogger(true, os.Stdout)
+	if err != nil {
+		log.Fatal(err)
+	}
+	logger.Infof("STARTUP: Version %s. Config loaded.", version.APP_VERSION)
+
+	// check destination first before we attempt to load
+	// area fences.
+	nestsDBStore, err := db_store.NewNestsDBStore(cfg.NestsDb, logger)
+	if err != nil {
+		logger.Errorf("failed to init nests db for db importer: %v", err)
+		os.Exit(1)
+	}
+
+	if _, _, err := nestsDBStore.CheckMigrate(DEFAULT_NESTS_MIGRATIONS_PATH); err != nil {
+		logger.Errorf("error initing nests db: %v", err)
+		os.Exit(1)
+	}
+
+	var golbatDBStore *db_store.GolbatDBStore
+
+	if cfg.GolbatDb == nil {
+		logger.Warnf("Skipping spawnpoint count gathering and filtering: no golbat_db configured")
+	} else {
+		// check destination first before we attempt to load
+		// area fences.
+		var err error
+		golbatDBStore, err = db_store.NewGolbatDBStore(*cfg.GolbatDb, logger)
+		if err != nil {
+			logger.Errorf("failed to init golbat db for spawnpoint counts: %v", err)
+			os.Exit(1)
+		}
+	}
+
+	dbRefresher := filters.NewDBRefresher(logger, nestsDBStore, golbatDBStore)
+
+	var wg sync.WaitGroup
+	defer wg.Wait()
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	defer cancelFn()
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer cancelFn()
+
+		sig_ch := make(chan os.Signal, 1)
+		signal.Notify(sig_ch, syscall.SIGINT, syscall.SIGTERM)
+		select {
+		case <-ctx.Done():
+			// something else told us to exit
+		case sig := <-sig_ch:
+			logger.Infof("received signal '%s'", sig.String())
+		}
+	}()
+
+	logger.Infof("Gathering missing spawnpoints, running filters, and activating/deactivating nests...")
+	refreshConfig := filters.RefreshNestConfig{
+		Concurrency:             cfg.Filters.Concurrency,
+		ForceSpawnpointsRefresh: *allSpawnpointsFlag,
+		MinAreaM2:               cfg.Filters.MinAreaM2,
+		MaxAreaM2:               cfg.Filters.MaxAreaM2,
+		MinSpawnpoints:          cfg.Filters.MinSpawnpoints,
+		MaxOverlapPercent:       cfg.Filters.MaxOverlapPercent,
+	}
+
+	err = dbRefresher.RefreshAllNests(ctx, refreshConfig)
+	if err == nil {
+		logger.Infof("Done activating/deactivating nests")
+	} else {
+		logger.Fatalf("failed to filter and activate/deactivate nests: %v", err)
+	}
+
+	logger.Infof("Done. Don't forget to tell Fletchling to reload!")
+}

--- a/bin/fletchling-osm-importer/fletchling-osm-importer.go
+++ b/bin/fletchling-osm-importer/fletchling-osm-importer.go
@@ -64,6 +64,7 @@ func main() {
 	allAreasFlag := flagSet.Bool("all-areas", false, "import all areas found in your areas source")
 	newAreasFlag := flagSet.Bool("new-areas", false, "import all areas found in your areas source that have not been imported yet")
 	skipActivateFlag := flagSet.Bool("skip-activation", false, "skips the final spawnpoint count gathering, filtering, and activation of new nests")
+	versionFlag := flagSet.Bool("version", false, "print the version of this tool and exit")
 
 	err := flagSet.Parse(os.Args[1:])
 	if err != nil {
@@ -74,6 +75,11 @@ func main() {
 
 	if *helpFlag {
 		usage(flagSet, os.Stdout)
+		os.Exit(0)
+	}
+
+	if *versionFlag {
+		fmt.Fprintf(os.Stdout, "%s\n", version.APP_VERSION)
 		os.Exit(0)
 	}
 
@@ -109,7 +115,10 @@ func main() {
 		cfg.Logging.Debug = true
 	}
 
-	logger := cfg.CreateLogger(true)
+	logger, err := cfg.CreateLogger(true, os.Stdout)
+	if err != nil {
+		log.Fatal(err)
+	}
 	logger.Infof("STARTUP: Version %s. Config loaded.", version.APP_VERSION)
 
 	// check destination first before we attempt to load

--- a/bin/fletchling/fletchling.go
+++ b/bin/fletchling/fletchling.go
@@ -48,6 +48,7 @@ func main() {
 	debugFlag := flagSet.Bool("debug", false, "override config and turn on debug logging")
 	flagSet.BoolVar(helpFlag, "h", false, "help!")
 	configFileFlag := flagSet.String("f", DEFAULT_CONFIG_FILENAME, "config file to use")
+	versionFlag := flagSet.Bool("version", false, "print the version of this tool and exit")
 
 	err := flagSet.Parse(os.Args[1:])
 	if err != nil {
@@ -58,6 +59,11 @@ func main() {
 
 	if *helpFlag {
 		usage(flagSet, os.Stdout)
+		os.Exit(0)
+	}
+
+	if *versionFlag {
+		fmt.Fprintf(os.Stdout, "%s\n", version.APP_VERSION)
 		os.Exit(0)
 	}
 
@@ -78,7 +84,10 @@ func main() {
 		cfg.Logging.Debug = true
 	}
 
-	logger := cfg.CreateLogger(true)
+	logger, err := cfg.CreateLogger(true, os.Stdout)
+	if err != nil {
+		log.Fatal(err)
+	}
 	logger.Infof("STARTUP: Version %s. Config loaded.", version.APP_VERSION)
 
 	statsCollector := stats_collector.GetStatsCollector(cfg)

--- a/docker-db-exporter.sh
+++ b/docker-db-exporter.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# run fletchling-db-exporter under docker
+
+cd `dirname $0`
+
+which docker-compose > /dev/null
+if [ $? -eq 0 ]; then
+  command='docker-compose'
+else
+  command='docker compose'
+fi
+
+$command exec fletchling-tools ./fletchling-db-exporter "$@"

--- a/docker-db-refresher.sh
+++ b/docker-db-refresher.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# run fletchling-db-refresher under docker
+
+cd `dirname $0`
+
+which docker-compose > /dev/null
+if [ $? -eq 0 ]; then
+  command='docker-compose'
+else
+  command='docker compose'
+fi
+
+$command exec fletchling-tools ./fletchling-db-refresher "$@"


### PR DESCRIPTION
* db-refresher

This is a tool that imitates the behavior of the
/api/config/reload?refresh=1 or all-spawnpoints=1 api calls.

This can be used to refresh the DB without reloading fletchling and may be useful to ship separately in case of updates that don't require restarting fletchling.

If satisfied with the results after running this tool, simply reload fletchling with the /api/config call without any query parameters.

* db-exporter

This is a tool that exports nests in the DB. A single nest can be exported as a geojson Feature or nests for a particular area or all areas can be exported as a FeatureCollection.