### PR TITLE
Handle query params in koji url

### DIFF
--- a/areas/config.go
+++ b/areas/config.go
@@ -17,9 +17,10 @@ type Config struct {
 	CacheDir      string `koanf:"cache_dir"`
 	CacheFilename string `koanf:"cache_filename"`
 
-	// computed during validation
-	KojiBaseUrl string `koanf:"-"`
-	KojiProject string `koanf:"-"`
+	// computed during validation:
+	KojiBaseUrl       string     `koanf:"-"`
+	KojiProject       string     `koanf:"-"`
+	KojiProjectParams url.Values `koanf:"-"`
 }
 
 func (cfg *Config) Validate() error {
@@ -44,7 +45,9 @@ func (cfg *Config) Validate() error {
 			return fmt.Errorf("'areas.koji_url' looks malformed: the project is missing")
 		}
 
+		cfg.KojiProjectParams = uri.Query()
 		uri.Path = ""
+		uri.RawQuery = ""
 		cfg.KojiBaseUrl = uri.String()
 
 		return nil

--- a/exporters/koji.go
+++ b/exporters/koji.go
@@ -2,6 +2,7 @@ package exporters
 
 import (
 	"context"
+	"net/url"
 
 	"github.com/paulmach/orb/geojson"
 	"github.com/sirupsen/logrus"
@@ -10,9 +11,10 @@ import (
 )
 
 type KojiExporter struct {
-	logger      *logrus.Logger
-	kojiCli     *koji_client.APIClient
-	projectName string
+	logger        *logrus.Logger
+	kojiCli       *koji_client.APIClient
+	projectName   string
+	projectParams url.Values
 }
 
 func (*KojiExporter) ExporterName() string {
@@ -20,7 +22,7 @@ func (*KojiExporter) ExporterName() string {
 }
 
 func (exporter *KojiExporter) ExportFeatures(ctx context.Context) ([]*geojson.Feature, error) {
-	fc, err := exporter.kojiCli.GetFeatureCollection(ctx, exporter.projectName)
+	fc, err := exporter.kojiCli.GetFeatureCollection(ctx, exporter.projectName, exporter.projectParams)
 	if err != nil {
 		return nil, err
 	}
@@ -47,11 +49,12 @@ func (exporter *KojiExporter) ExportFeatures(ctx context.Context) ([]*geojson.Fe
 
 }
 
-func NewKojiExporter(logger *logrus.Logger, kojiCli *koji_client.APIClient, projectName string) (*KojiExporter, error) {
+func NewKojiExporter(logger *logrus.Logger, kojiCli *koji_client.APIClient, projectName string, projectParams url.Values) (*KojiExporter, error) {
 	exporter := &KojiExporter{
-		logger:      logger,
-		kojiCli:     kojiCli,
-		projectName: projectName,
+		logger:        logger,
+		kojiCli:       kojiCli,
+		projectName:   projectName,
+		projectParams: projectParams,
 	}
 	return exporter, nil
 }

--- a/koji_client/api.go
+++ b/koji_client/api.go
@@ -56,8 +56,13 @@ func (cli *APIClient) makePublicRequest(ctx context.Context, method, url_str str
 	return resp, nil
 }
 
-func (cli *APIClient) GetFeatureCollection(ctx context.Context, project string) (*geojson.FeatureCollection, error) {
-	resp, err := cli.makePublicRequest(ctx, "GET", "/geofence/feature-collection/"+project, nil)
+func (cli *APIClient) GetFeatureCollection(ctx context.Context, project string, params url.Values) (*geojson.FeatureCollection, error) {
+	urlPath := "/geofence/feature-collection/" + project
+	if paramsStr := params.Encode(); paramsStr != "" {
+		urlPath += "?" + paramsStr
+	}
+
+	resp, err := cli.makePublicRequest(ctx, "GET", urlPath, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/processor/nest_loader/koji.go
+++ b/processor/nest_loader/koji.go
@@ -3,6 +3,7 @@ package nest_loader
 import (
 	"context"
 	"fmt"
+	"net/url"
 
 	"github.com/sirupsen/logrus"
 
@@ -12,10 +13,11 @@ import (
 )
 
 type KojiNestLoader struct {
-	logger       *logrus.Logger
-	kojiCli      *koji_client.APIClient
-	projectName  string
-	nestsDBStore *db_store.NestsDBStore
+	logger        *logrus.Logger
+	kojiCli       *koji_client.APIClient
+	projectName   string
+	projectParams url.Values
+	nestsDBStore  *db_store.NestsDBStore
 }
 
 func (*KojiNestLoader) LoaderName() string {
@@ -23,7 +25,7 @@ func (*KojiNestLoader) LoaderName() string {
 }
 
 func (loader *KojiNestLoader) LoadNests(ctx context.Context) ([]*models.Nest, error) {
-	fc, err := loader.kojiCli.GetFeatureCollection(ctx, loader.projectName)
+	fc, err := loader.kojiCli.GetFeatureCollection(ctx, loader.projectName, loader.projectParams)
 	if err != nil {
 		return nil, err
 	}
@@ -69,12 +71,13 @@ func (loader *KojiNestLoader) LoadNests(ctx context.Context) ([]*models.Nest, er
 	return kojiNests, nil
 }
 
-func NewKojiNestLoader(logger *logrus.Logger, kojiCli *koji_client.APIClient, projectName string, nestsDBStore *db_store.NestsDBStore) *KojiNestLoader {
+func NewKojiNestLoader(logger *logrus.Logger, kojiCli *koji_client.APIClient, projectName string, projectParams url.Values, nestsDBStore *db_store.NestsDBStore) *KojiNestLoader {
 	st := &KojiNestLoader{
-		logger:       logger,
-		kojiCli:      kojiCli,
-		projectName:  projectName,
-		nestsDBStore: nestsDBStore,
+		logger:        logger,
+		kojiCli:       kojiCli,
+		projectName:   projectName,
+		projectParams: projectParams,
+		nestsDBStore:  nestsDBStore,
 	}
 	return st
 }


### PR DESCRIPTION
This checks for and properly preserves the query params that should be used when querying for the project's feature collections..

Fixes #51